### PR TITLE
fix: NotificationUuid is empty after decoding

### DIFF
--- a/src/Models/AppStoreDataTypes.cs
+++ b/src/Models/AppStoreDataTypes.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Mimo.AppStoreServerLibrary.Models;
 
 /// <summary>
@@ -52,6 +54,7 @@ public class ResponseBodyV2DecodedPayload
     /// <summary>
     /// A unique identifier for the notification. Use this value to identify a duplicate notification.
     /// </summary>
+    [JsonPropertyName("notificationUUID")]
     public Guid NotificationUuid { get; set; }
 }
 

--- a/tests/SignedDataVerifierTest.cs
+++ b/tests/SignedDataVerifierTest.cs
@@ -60,6 +60,7 @@ public class SignedDataVerifierTest
         Assert.IsType<ResponseBodyV2DecodedPayload>(result);
         Assert.NotNull(result);
         Assert.Equal("TEST", result.NotificationType);
+        Assert.NotEqual(result.NotificationUuid, Guid.Empty);
     }
 
     [Fact]


### PR DESCRIPTION
Hi, this PR fixes the issue with the `NotificationUuid` property being empty.

I have also added a test to ensure the property is not empty.