### PR TITLE
feat: allow passing a bundleId to override the one specified in the constructor

### DIFF
--- a/src/AppStoreServerApiClient.cs
+++ b/src/AppStoreServerApiClient.cs
@@ -31,28 +31,34 @@ public class AppStoreServerApiClient(
 {
     private static readonly Lazy<HttpClient> DefaultHttpClient = new(() => new HttpClient());
     private readonly HttpClient httpClient = httpClient ?? DefaultHttpClient.Value;
+    private readonly string _bundleId = bundleId;
 
     /// <summary>
     /// Get the statuses for all of a customer’s auto-renewable subscriptions in your app.
     /// </summary>
     /// <param name="transactionId"> The identifier of a transaction that belongs to the customer, and which may be an original transaction identifier</param>
+    /// <param name="bundleId">An optional bundle ID that overrides the instance-level bundle ID for this request.</param>
     /// <returns>The status for all the customer’s subscriptions, organized by their subscription group identifier.</returns>
-    public Task<SubscriptionStatusResponse> GetAllSubscriptionStatuses(string transactionId)
+    public Task<SubscriptionStatusResponse> GetAllSubscriptionStatuses(string transactionId, string? bundleId = null)
     {
         //Call to https://developer.apple.com/documentation/appstoreserverapi/get_all_subscription_statuses
 
         string path = $"/inApps/v1/subscriptions/{transactionId}";
 
-        return this.MakeRequest<SubscriptionStatusResponse>(path, HttpMethod.Get)!;
+        return this.MakeRequest<SubscriptionStatusResponse>(path, HttpMethod.Get, bundleId: bundleId)!;
     }
 
     /// <summary>
     /// Get a list of notifications that the App Store server attempted to send to your server.
     /// </summary>
+    /// <param name="notificationHistoryRequest">The request body containing the notification history query parameters.</param>
+    /// <param name="paginationToken">An optional pagination token for fetching subsequent pages of results.</param>
+    /// <param name="bundleId">An optional bundle ID that overrides the instance-level bundle ID for this request.</param>
     /// <returns>A list of notifications and their attempts</returns>
     public Task<NotificationHistoryResponse?> GetNotificationHistory(
         NotificationHistoryRequest notificationHistoryRequest,
-        string paginationToken = ""
+        string paginationToken = "",
+        string? bundleId = null
     )
     {
         //Call to https://developer.apple.com/documentation/appstoreserverapi/get_notification_history
@@ -68,15 +74,23 @@ public class AppStoreServerApiClient(
             path,
             HttpMethod.Post,
             queryParameters,
-            notificationHistoryRequest
+            notificationHistoryRequest,
+            bundleId: bundleId
         );
     }
 
     /// <summary>
     /// Get a customer’s in-app purchase transaction history for your app.
     /// </summary>
+    /// <param name="transactionId">The identifier of a transaction that belongs to the customer.</param>
+    /// <param name="revisionToken">An optional revision token for paginating through transaction history.</param>
+    /// <param name="bundleId">An optional bundle ID that overrides the instance-level bundle ID for this request.</param>
     /// <returns>A list of transactions associated with the provided Transaction ID</returns>
-    public Task<TransactionHistoryResponse?> GetTransactionHistory(string transactionId, string revisionToken = "")
+    public Task<TransactionHistoryResponse?> GetTransactionHistory(
+        string transactionId,
+        string revisionToken = "",
+        string? bundleId = null
+    )
     {
         //Call to https://developer.apple.com/documentation/appstoreserverapi/get_transaction_history
         Dictionary<string, string> queryParameters = new();
@@ -87,7 +101,7 @@ public class AppStoreServerApiClient(
 
         string path = $"/inApps/v2/history/{transactionId}";
 
-        return this.MakeRequest<TransactionHistoryResponse>(path, HttpMethod.Get, queryParameters);
+        return this.MakeRequest<TransactionHistoryResponse>(path, HttpMethod.Get, queryParameters, bundleId: bundleId);
     }
 
     /// <summary>
@@ -95,51 +109,59 @@ public class AppStoreServerApiClient(
     /// </summary>
     /// <param name="transactionId">The transaction identifier for which you're providing consumption information. You receive this identifier in the CONSUMPTION_REQUEST notification the App Store sends to your server.</param>
     /// <param name="consumptionRequest">The request body containing consumption information.</param>
+    /// <param name="bundleId">An optional bundle ID that overrides the instance-level bundle ID for this request.</param>
     /// <exception cref="ApiException">Thrown when a response indicates the request could not be processed</exception>
     /// <remarks>
     /// See <see href="https://developer.apple.com/documentation/appstoreserverapi/send_consumption_information">Send Consumption Information</see>
     /// </remarks>
-    public Task SendConsumptionData(string transactionId, ConsumptionRequest consumptionRequest)
+    public Task SendConsumptionData(
+        string transactionId,
+        ConsumptionRequest consumptionRequest,
+        string? bundleId = null
+    )
     {
         string path = $"/inApps/v1/transactions/consumption/{transactionId}";
 
-        return this.MakeRequest<object?>(path, HttpMethod.Put, null, consumptionRequest, false);
+        return this.MakeRequest<object?>(path, HttpMethod.Put, null, consumptionRequest, false, bundleId: bundleId);
     }
 
     /// <summary>
     /// Get information about a single transaction for your app.
     /// </summary>
     /// <param name="transactionId">The identifier of a transaction that belongs to the customer, and which may be an original transaction identifier.</param>
+    /// <param name="bundleId">An optional bundle ID that overrides the instance-level bundle ID for this request.</param>
     /// <exception cref="ApiException">Thrown when a response indicates the request could not be processed</exception>
     /// <remarks>
     /// See <see href="https://developer.apple.com/documentation/appstoreserverapi/get-v1-transactions-_transactionid_">Get Transaction Info</see>
     /// </remarks>
-    public Task<TransactionInfoResponse?> GetTransactionInfo(string transactionId)
+    public Task<TransactionInfoResponse?> GetTransactionInfo(string transactionId, string? bundleId = null)
     {
         string path = $"/inApps/v1/transactions/{transactionId}";
 
-        return this.MakeRequest<TransactionInfoResponse>(path, HttpMethod.Get);
+        return this.MakeRequest<TransactionInfoResponse>(path, HttpMethod.Get, bundleId: bundleId);
     }
 
     /// <summary>
     /// Get a customer’s in-app purchases from a receipt using the order ID.
     /// </summary>
     /// <param name="orderId">The order ID for in-app purchases that belong to the customer.</param>
+    /// <param name="bundleId">An optional bundle ID that overrides the instance-level bundle ID for this request.</param>
     /// <exception cref="ApiException">Thrown when a response indicates the request could not be processed</exception>
     /// <remarks>
     /// See <see href="https://developer.apple.com/documentation/appstoreserverapi/get-v1-lookup-_orderid_">Look Up Order ID</see>
     /// </remarks>
-    public Task<OrderLookupResponse> LookUpOrderId(string orderId)
+    public Task<OrderLookupResponse> LookUpOrderId(string orderId, string? bundleId = null)
     {
         string path = $"/inApps/v1/lookup/{orderId}";
 
-        return this.MakeRequest<OrderLookupResponse>(path, HttpMethod.Get)!;
+        return this.MakeRequest<OrderLookupResponse>(path, HttpMethod.Get, bundleId: bundleId)!;
     }
 
     /// <summary>
     /// Returns a signed JWT token that can be used to make requests to the App Store Server API directly.
     /// </summary>
-    public string GetApiToken()
+    /// <param name="bundleId">An optional bundle ID that overrides the instance-level bundle ID for generating the token.</param>
+    public string GetApiToken(string? bundleId = null)
     {
         var prvKey = ECDsa.Create();
         prvKey.ImportFromPem(signingKey);
@@ -152,7 +174,7 @@ public class AppStoreServerApiClient(
             {
                 { "iss", issuerId },
                 { "aud", "appstoreconnect-v1" },
-                { "bid", bundleId },
+                { "bid", bundleId ?? _bundleId },
             },
             TokenType = "JWT",
         };
@@ -169,11 +191,12 @@ public class AppStoreServerApiClient(
         HttpMethod method,
         Dictionary<string, string>? queryParameters = null,
         object? body = null,
-        bool fetchResponse = true
+        bool fetchResponse = true,
+        string? bundleId = null
     )
         where TReturn : class
     {
-        string token = this.GetApiToken();
+        string token = this.GetApiToken(bundleId);
 
         UriBuilder builder = new(environment.BaseUrl) { Path = path };
 

--- a/src/SignedDataVerifier.cs
+++ b/src/SignedDataVerifier.cs
@@ -15,6 +15,8 @@ public class SignedDataVerifier(
     string bundleId
 )
 {
+    private readonly string _bundleId = bundleId;
+
     // To compatibility with the previous version (<= 0.1.0) of the constructor
     public SignedDataVerifier(
         byte[] appleRootCertificate,
@@ -36,9 +38,13 @@ public class SignedDataVerifier(
     /// See <see href="https://developer.apple.com/documentation/appstoreservernotifications/signedpayload">signedPayload</see>
     /// </summary>
     /// <param name="signedPayload">The payload received by your server</param>
+    /// <param name="bundleId">An optional bundle ID that overrides the instance-level bundle ID for this verification.</param>
     /// <returns>The decoded payload after verification</returns>
     /// <exception cref="VerificationException">Thrown if the data could not be verified</exception>
-    public async Task<ResponseBodyV2DecodedPayload> VerifyAndDecodeNotification(string signedPayload)
+    public async Task<ResponseBodyV2DecodedPayload> VerifyAndDecodeNotification(
+        string signedPayload,
+        string? bundleId = null
+    )
     {
         string payload = await VerifySignedData(signedPayload);
 
@@ -60,10 +66,11 @@ public class SignedDataVerifier(
             );
         }
 
-        if (decodedPayload.Data.BundleId != bundleId)
+        string effectiveBundleId = bundleId ?? _bundleId;
+        if (decodedPayload.Data.BundleId != effectiveBundleId)
         {
             throw new VerificationException(
-                $"BundleId in payload does not match expected bundleId. Expected : {bundleId}, Actual : {decodedPayload.Data.BundleId}"
+                $"BundleId in payload does not match expected bundleId. Expected : {effectiveBundleId}, Actual : {decodedPayload.Data.BundleId}"
             );
         }
 

--- a/tests/AppStoreServerApiClientTest.cs
+++ b/tests/AppStoreServerApiClientTest.cs
@@ -1,3 +1,4 @@
+using Microsoft.IdentityModel.JsonWebTokens;
 using Mimo.AppStoreServerLibrary;
 using Mimo.AppStoreServerLibrary.Models;
 using RichardSzalay.MockHttp;
@@ -181,5 +182,41 @@ public class AppStoreServerApiClientTest
             transaction => Assert.Equal("signed_transaction_one", transaction),
             transaction => Assert.Equal("signed_transaction_two", transaction)
         );
+    }
+
+    [Fact]
+    public void GetApiToken_WithBundleIdOverride_UsesOverriddenBundleId()
+    {
+        var client = new AppStoreServerApiClient(
+            TestSigningKey,
+            KeyId,
+            IssuerId,
+            BundleId,
+            AppStoreEnvironment.LocalTesting
+        );
+
+        string token = client.GetApiToken(bundleId: "com.override.app");
+
+        var handler = new JsonWebTokenHandler();
+        var jwt = handler.ReadJsonWebToken(token);
+        Assert.Equal("com.override.app", jwt.GetClaim("bid").Value);
+    }
+
+    [Fact]
+    public void GetApiToken_WithoutOverride_UsesConstructorBundleId()
+    {
+        var client = new AppStoreServerApiClient(
+            TestSigningKey,
+            KeyId,
+            IssuerId,
+            BundleId,
+            AppStoreEnvironment.LocalTesting
+        );
+
+        string token = client.GetApiToken();
+
+        var handler = new JsonWebTokenHandler();
+        var jwt = handler.ReadJsonWebToken(token);
+        Assert.Equal(BundleId, jwt.GetClaim("bid").Value);
     }
 }

--- a/tests/SignedDataVerifierTest.cs
+++ b/tests/SignedDataVerifierTest.cs
@@ -285,4 +285,52 @@ public class SignedDataVerifierTest
 
         Assert.Contains("Environment in payload does not match expected environment.", exception.Message);
     }
+
+    [Fact]
+    public async Task VerifyAndDecode_WithBundleIdOverride_Success()
+    {
+        string testNotificationPayload = await File.ReadAllTextAsync(
+            "./MockedSignedData/InputFor_VerifyAndDecode_TestNotification_Success.txt"
+        );
+
+        // Construct verifier with a wrong default bundleId
+        var dataVerifier = new SignedDataVerifier(
+            Convert.FromBase64String(RootCaBase64Encoded),
+            false,
+            AppStoreEnvironment.Sandbox,
+            "com.wrong.default"
+        );
+
+        // Override with the correct bundleId — should succeed
+        ResponseBodyV2DecodedPayload result = await dataVerifier.VerifyAndDecodeNotification(
+            testNotificationPayload,
+            bundleId: BundleId
+        );
+
+        Assert.NotNull(result);
+        Assert.Equal("TEST", result.NotificationType);
+    }
+
+    [Fact]
+    public async Task VerifyAndDecode_WithWrongBundleIdOverride_Fails()
+    {
+        string testNotificationPayload = await File.ReadAllTextAsync(
+            "./MockedSignedData/InputFor_VerifyAndDecode_TestNotification_Success.txt"
+        );
+
+        // Construct verifier with the correct default bundleId
+        var dataVerifier = new SignedDataVerifier(
+            Convert.FromBase64String(RootCaBase64Encoded),
+            false,
+            AppStoreEnvironment.Sandbox,
+            BundleId
+        );
+
+        // Override with a wrong bundleId — override takes precedence, so it should fail
+        var exception = await Assert.ThrowsAsync<VerificationException>(
+            () => dataVerifier.VerifyAndDecodeNotification(testNotificationPayload, bundleId: "com.wrong.override")
+        );
+
+        Assert.Contains("BundleId in payload does not match expected bundleId.", exception.Message);
+    }
 }


### PR DESCRIPTION
Added an optional `bundleId` param to the verifier and client classes.

This way, one can register a them as services for the DI that use the http client factory while still be able to work with multiple bundle ids, e.g.:
```csharp
  builder.Services.AddHttpClient<AppStoreServerApiClient>()
	  .AddTypedClient((httpClient, sp) =>
	  {
	      return new AppStoreServerApiClient(..., httpClient);
	  });
  ```